### PR TITLE
docs(samples): remove unsupported field RecognitionResult

### DIFF
--- a/samples/snippets/src/main/java/com/example/mediatranslation/TranslateFromMic.java
+++ b/samples/snippets/src/main/java/com/example/mediatranslation/TranslateFromMic.java
@@ -60,14 +60,11 @@ public class TranslateFromMic {
             public void onResponse(StreamingTranslateSpeechResponse response) {
               StreamingTranslateSpeechResult res = response.getResult();
               String translation = res.getTextTranslationResult().getTranslation();
-              String source = res.getRecognitionResult();
 
               if (res.getTextTranslationResult().getIsFinal()) {
                 System.out.println(String.format("\nFinal translation: %s", translation));
-                System.out.println(String.format("Final recognition result: %s", source));
               } else {
                 System.out.println(String.format("\nPartial translation: %s", translation));
-                System.out.println(String.format("Partial recognition result: %s", source));
               }
             }
 


### PR DESCRIPTION
`RecognitionResult` was removed in [0.4.0](https://github.com/googleapis/java-mediatranslation/releases/tag/v0.4.0).

Fixes #629 